### PR TITLE
add fxhash as a point of comparaison, because it is the commonly used…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 rand = "0.8.5"
 lazy_static = "1.4.0"
 compact_str = "0.7.0"
+rustc-hash = "1.1"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,7 +2,7 @@
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use keyword_match_experiment::{
-    match_keyword_perfect_hash, match_keyword_baseline, match_keyword_rust_custom_hash, match_keyword_rust_hash,
+    match_keyword_perfect_hash, match_keyword_baseline, match_keyword_rust_custom_hash, match_keyword_rust_hash, match_keyword_rust_hash_fx,
     simd_str_match, str_match,
     utils::{generate_keywords, read_keys_from_file},
 };
@@ -46,6 +46,16 @@ fn bench_keyword_match(c: &mut Criterion) {
             b.iter(|| {
                 for c in &candidates {
                     black_box(match_keyword_rust_hash(c));
+                }
+            });
+        },
+    );
+    group.bench_function(
+        BenchmarkId::new("Rust FxHashMap(rustc-hasher)", &param),
+        |b| {
+            b.iter(|| {
+                for c in &candidates {
+                    black_box(match_keyword_rust_hash_fx(c));
                 }
             });
         },

--- a/src/keyword_match.rs
+++ b/src/keyword_match.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 
 use lazy_static::lazy_static;
 
@@ -17,6 +18,9 @@ lazy_static! {
     };
     pub static ref KEYWORD_RUST_HASH_TABLE: HashSet<&'static str> =
         keyword_list::KEYWORDS.iter().copied().collect();
+
+    pub static ref KEYWORD_RUST_HASH_TABLE_FX: FxHashSet<&'static str> =
+        keyword_list::KEYWORDS.iter().copied().collect();
 }
 
 #[inline]
@@ -30,6 +34,11 @@ pub fn match_keyword_rust_custom_hash(s: &str) -> bool {
 #[inline]
 pub fn match_keyword_rust_hash(s: &str) -> bool {
     KEYWORD_RUST_HASH_TABLE.contains(s)
+}
+
+#[inline]
+pub fn match_keyword_rust_hash_fx(s: &str) -> bool {
+    KEYWORD_RUST_HASH_TABLE_FX.contains(s)
 }
 
 #[inline]
@@ -145,6 +154,7 @@ fn test_hash_correctness() {
         let expected = match_keyword_baseline(key);
         assert_eq!(expected, match_keyword_perfect_hash(key));
         assert_eq!(expected, match_keyword_rust_hash(key));
+        assert_eq!(expected, match_keyword_rust_hash_fx(key));
         assert_eq!(expected, match_keyword_rust_custom_hash(key));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub mod utils;
 use std::simd::{Simd, SimdPartialEq, ToBitMask};
 
 pub use keyword_list::{MAX_JS_KEYWORD_LENGTH, MIN_JS_KEYWORD_LENGTH};
-pub use keyword_match::{match_keyword_perfect_hash, match_keyword_baseline, match_keyword_rust_hash, match_keyword_rust_custom_hash};
+pub use keyword_match::{match_keyword_perfect_hash, match_keyword_baseline, match_keyword_rust_hash, match_keyword_rust_hash_fx, match_keyword_rust_custom_hash};
 
 pub const ELEMENTS: usize = 16;
 


### PR DESCRIPTION
… hasher in rust using a mainstream hash function (https://crates.io/crates/rustc-hash)